### PR TITLE
Load and display organisation data

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -8,5 +8,9 @@ service cloud.firestore {
       // TODO: correct permissions
       allow read, create, update, delete;
     }
+    match /organisations/{organisationId} {
+      // TODO: only allow reads of orgs of which user is a member?
+      allow read: if request.auth.uid != null;
+    }
   }
 }

--- a/src/components/AppDrawer.js
+++ b/src/components/AppDrawer.js
@@ -10,7 +10,7 @@ import Typography from "@material-ui/core/Typography";
 import Divider from "@material-ui/core/Divider";
 import Hidden from "@material-ui/core/Hidden";
 import { Link } from "react-router-dom";
-import AppDrawerAuth from "./AppDrawerAuth";
+import AppDrawerAuthContainer from "./AppDrawerAuthContainer";
 
 const styles = theme => ({
   paper: {
@@ -71,7 +71,7 @@ const AppDrawer = ({
         </ListItem>
       </List>
       <Divider />
-      <AppDrawerAuth />
+      <AppDrawerAuthContainer />
     </div>
   );
 

--- a/src/components/AppDrawerAuth.js
+++ b/src/components/AppDrawerAuth.js
@@ -1,44 +1,29 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { compose } from "redux";
-import { connect } from "react-redux";
 import List from "@material-ui/core/List";
 import ListItem from "@material-ui/core/ListItem";
 import ListItemText from "@material-ui/core/ListItemText";
-import { isEmpty, withFirebase } from "react-redux-firebase";
 
-const AppDrawerAuth = ({ auth, firebase, organisation }) => {
-  if (isEmpty(auth)) {
-    return null;
-  }
+const AppDrawerAuth = ({ profile, organisation, signOut }) => {
   return (
     <List>
       <ListItem>
-        <ListItemText secondary={`Signed in as ${auth.email}`} />
+        <ListItemText secondary={`Signed in as ${profile.email}`} />
       </ListItem>
       <ListItem>
         <ListItemText secondary={`Organisation ${organisation.id}`} />
       </ListItem>
       <ListItem button>
-        <ListItemText
-          primary="Sign Out"
-          onClick={() => {
-            firebase.auth().signOut();
-          }}
-        />
+        <ListItemText primary="Sign Out" onClick={signOut} />
       </ListItem>
     </List>
   );
 };
 
 AppDrawerAuth.propTypes = {
-  auth: PropTypes.object.isRequired,
-  firebase: PropTypes.object.isRequired
+  profile: PropTypes.object.isRequired,
+  organisation: PropTypes.object.isRequired,
+  signOut: PropTypes.func.isRequired
 };
 
-const mapStateToProps = state => ({
-  auth: state.firebase.auth,
-  organisation: state.organisation
-});
-
-export default compose(connect(mapStateToProps), withFirebase)(AppDrawerAuth);
+export default AppDrawerAuth;

--- a/src/components/AppDrawerAuthContainer.js
+++ b/src/components/AppDrawerAuthContainer.js
@@ -1,0 +1,52 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { compose } from "redux";
+import { connect } from "react-redux";
+import { isEmpty, firestoreConnect } from "react-redux-firebase";
+import AppDrawerAuth from "./AppDrawerAuth";
+
+const enhance = compose(
+  firestoreConnect(["organisations"]),
+  connect(({ firebase, firestore, organisation }) => ({
+    organisation: organisation,
+    organisations: firestore.data.organisations,
+    profile: firebase.profile
+  }))
+);
+
+const AppDrawerAuthContainer = ({
+  firebase,
+  organisation,
+  organisations,
+  profile
+}) => {
+  if (isEmpty(profile)) {
+    return null;
+  }
+
+  let org;
+  if (isEmpty(organisations) || !organisation) {
+    org = { id: "<unknown>" };
+  } else {
+    org = organisations[organisation];
+  }
+
+  return (
+    <AppDrawerAuth
+      profile={profile}
+      organisation={org}
+      signOut={firebase.logout}
+    />
+  );
+};
+
+AppDrawerAuthContainer.propTypes = {
+  firebase: PropTypes.shape({
+    logout: PropTypes.func.isRequired
+  }),
+  organisation: PropTypes.string,
+  organisations: PropTypes.object,
+  profile: PropTypes.object.isRequired
+};
+
+export default enhance(AppDrawerAuthContainer);

--- a/src/reducers/organisations.js
+++ b/src/reducers/organisations.js
@@ -1,25 +1,17 @@
 import { actionTypes } from "react-redux-firebase";
 import { SET_ORGANISATION } from "../actions/organisations";
 
-const initialState = {
-  id: null
-};
+const initialState = null;
 
 export const organisationReducer = (state = initialState, action) => {
   switch (action.type) {
     case SET_ORGANISATION:
-      return {
-        ...state,
-        id: action.organisationId
-      };
+      return action.organisationId;
     // set default organisation
     case actionTypes.SET_PROFILE:
       const organisations = action.profile.organisations;
-      if (!state.organisationId && organisations && organisations.length) {
-        return {
-          ...state,
-          id: organisations[0].id
-        };
+      if (!state && organisations && organisations.length) {
+        return organisations[0];
       }
       return state;
     default:


### PR DESCRIPTION
This wraps the auth widget in a container which takes responsibility for fetching organisation data and passing it down to the (boring, stateless) presentation component.

It's a bit dumb, as it just loads anything/everything in the `organisations` collection at the moment, but it mostly works and shouldn't fail if an `organisations` collection doesn't exist or the `organisations` property is missing from a user profile.

I've taken the liberty of simplifying the global `state.organisation` from an object to a string (or `null`), as I am assuming this was intended to track the "current" organisation for the view? But perhaps you intended something else? Anyway, very happy to make any necessary changes to this.