### PR TITLE
Scroll to top on navigation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import React from "react";
 import { BrowserRouter, Route, Switch } from "react-router-dom";
 import ReactGA from "react-ga";
 import Config from "./Config";
+import ScrollToTop from "./components/ScrollToTop";
 
 import AuthedRoute from "./router/AuthedRoute";
 import DashboardPage from "./pages/DashboardPage";
@@ -36,7 +37,7 @@ const App = () => (
   <MuiThemeProvider theme={theme}>
     <CssBaseline />
     <BrowserRouter>
-      <React.Fragment>
+      <ScrollToTop>
         <Switch>
           <AuthedRoute exact path="/" component={() => <DashboardPage />} />
           <AuthedRoute exact path="/boxes" component={() => <BoxesPage />} />
@@ -74,7 +75,7 @@ const App = () => (
         </Switch>
         {/* this is outside the switch so the 404 works */}
         <Route path="/" render={recordPageview} />
-      </React.Fragment>
+      </ScrollToTop>
     </BrowserRouter>
   </MuiThemeProvider>
 );

--- a/src/components/ScrollToTop.js
+++ b/src/components/ScrollToTop.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { withRouter } from "react-router-dom";
+
+class ScrollToTop extends React.Component {
+  componentDidUpdate(prevProps) {
+    if (
+      prevProps.location &&
+      this.props.location !== prevProps.location &&
+      !(
+        this.props.location.state &&
+        this.props.location.state.resetScroll === false
+      )
+    ) {
+      window.scrollTo(0, 0);
+    }
+  }
+
+  render() {
+    return this.props.children;
+  }
+}
+
+export default withRouter(ScrollToTop);


### PR DESCRIPTION
This doesn't handle scrolling to correct position on
back/forward. react-router-scroll does this but doesn't
support react-router v4.

Fixes #95